### PR TITLE
T/16 Introduce DataTransfer#files property, change the clipboardInput event and add the inputTranformation event

### DIFF
--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -34,8 +34,7 @@ import HtmlDataProcessor from '@ckeditor/ckeditor5-engine/src/dataprocessor/html
  * 2. prevent the default action of the native `paste` or `drop` event,
  * 3. fire {@link module:engine/view/document~Document#event:input} with a
  * {@link module:clipboard/datatransfer~DataTransfer `dataTransfer`} property.
- * 4. fire {@link module:clipboard/clipboard~Clipboard#event:inputTransformation} with a
- * {@link module:clipboard/clipboard~ClipboardInputEventData `data`} containing the clipboard data parsed to
+ * 4. fire {@link module:clipboard/clipboard~Clipboard#event:inputTransformation} with a `data` containing the clipboard data parsed to
  * a {@link module:engine/view/documentfragment~DocumentFragment view document fragment}.
  *
  * These action are performed by a low priority listeners, so they can be overridden by a normal ones

--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -111,7 +111,7 @@ export default class Clipboard extends Plugin {
 
 		// The clipboard paste pipeline.
 
-		this.listenTo( editingView, 'paste', ( evt, data ) => {
+		this.listenTo( editingView, 'input', ( evt, data ) => {
 			const dataTransfer = data.dataTransfer;
 			let content = '';
 
@@ -123,12 +123,10 @@ export default class Clipboard extends Plugin {
 
 			content = this._htmlDataProcessor.toView( content );
 
-			data.preventDefault();
-
-			editingView.fire( 'clipboardInput', { dataTransfer, content } );
+			editingView.fire( 'clipboardInputTransformation', { content } );
 		}, { priority: 'low' } );
 
-		this.listenTo( editingView, 'clipboardInput', ( evt, data ) => {
+		this.listenTo( editingView, 'clipboardInputTransformation', ( evt, data ) => {
 			if ( !data.content.isEmpty ) {
 				const dataController = this.editor.data;
 

--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -91,6 +91,10 @@ import HtmlDataProcessor from '@ckeditor/ckeditor5-engine/src/dataprocessor/html
  * @extends module:core.plugin~Plugin
  */
 export default class Clipboard extends Plugin {
+	static get pluginName() {
+		return 'clipboard';
+	}
+
 	/**
 	 * @inheritDoc
 	 */
@@ -123,10 +127,10 @@ export default class Clipboard extends Plugin {
 
 			content = this._htmlDataProcessor.toView( content );
 
-			editingView.fire( 'clipboardInputTransformation', { content } );
+			this.fire( 'inputTransformation', { content } );
 		}, { priority: 'low' } );
 
-		this.listenTo( editingView, 'clipboardInputTransformation', ( evt, data ) => {
+		this.listenTo( this, 'inputTransformation', ( evt, data ) => {
 			if ( !data.content.isEmpty ) {
 				const dataController = this.editor.data;
 
@@ -167,6 +171,8 @@ export default class Clipboard extends Plugin {
 			}
 		}, { priority: 'low' } );
 	}
+
+
 }
 
 /**

--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -135,7 +135,7 @@ export default class Clipboard extends Plugin {
 				const dataController = this.editor.data;
 
 				// Convert the pasted content to a model document fragment.
-				// Convertion is contextual, but in this case we need an "all allowed" context and for that
+				// Conversion is contextual, but in this case we need an "all allowed" context and for that
 				// we use the $clipboardHolder item.
 				const modelFragment = dataController.toModel( data.content, '$clipboardHolder' );
 
@@ -171,8 +171,6 @@ export default class Clipboard extends Plugin {
 			}
 		}, { priority: 'low' } );
 	}
-
-
 }
 
 /**

--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -191,18 +191,6 @@ export default class Clipboard extends Plugin {
 }
 
 /**
- * Fired with a `dataTransfer`, which comes from the clipboard (was pasted or dropped) and
- * should be processed in order to be inserted into the editor.
- * It's part of the {@link module:clipboard/clipboard~Clipboard "clipboard pipeline"}.
- *
- * @see module:clipboard/clipboardobserver~ClipboardObserver
- * @see module:clipboard/clipboard~Clipboard
- * @event module:engine/view/document~Document#event:input
- * @param {Object} data Event data.
- * @param {module:clipboard/datatransfer~DataTransfer} data.dataTransfer Data transfer instance.
- */
-
-/**
  * Fired with a `content`, which comes from the clipboard (was pasted or dropped) and
  * should be processed in order to be inserted into the editor.
  * It's part of the {@link module:clipboard/clipboard~Clipboard "clipboard pipeline"}.

--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -45,7 +45,15 @@ import HtmlDataProcessor from '@ckeditor/ckeditor5-engine/src/dataprocessor/html
  *
  * ### On {@link module:engine/view/document~Document#event:input}
  *
- * TODO
+ * This action is performed by a low priority listener, so it can be overridden by a normal one.
+ *
+ * At this stage the dataTransfer object can be processed by the features, which want to transform the original dataTransform.
+ *
+ *		this.listenTo( editor.editing.view, 'input', ( evt, data ) => {
+ *			const content = customTransform( data.dataTransfer.get( 'text/html' ) );
+ *			const transformedContent = transform( content );
+ * 			data.dataTransfer.set( 'text/html', transformedContent );
+ *		} );
  *
  * ### On {@link module:clipboard/clipboard~Clipboard#event:inputTransformation}
  *
@@ -57,7 +65,7 @@ import HtmlDataProcessor from '@ckeditor/ckeditor5-engine/src/dataprocessor/html
  * At this stage the pasted content can be processed by the features. E.g. a feature which wants to transform
  * a pasted text into a link can be implemented in this way:
  *
- *		this.listenTo( editor.editing.view, 'clipboardInput', ( evt, data ) => {
+ *		this.listenTo( editor.plugins.get( 'clipboard/clipboard' ), 'inputTransformation', ( evt, data ) => {
  *			if ( data.content.childCount == 1 && isUrlText( data.content.getChild( 0 ) ) ) {
  *				const linkUrl = data.content.getChild( 0 ).data;
  *

--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -95,7 +95,7 @@ export default class Clipboard extends Plugin {
 	 * @inheritDoc
 	 */
 	static get pluginName() {
-		return 'clipboard';
+		return 'clipboard/clipboard';
 	}
 
 	/**

--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -91,15 +91,11 @@ import HtmlDataProcessor from '@ckeditor/ckeditor5-engine/src/dataprocessor/html
  * @extends module:core.plugin~Plugin
  */
 export default class Clipboard extends Plugin {
-	static get pluginName() {
-		return 'clipboard';
-	}
-
 	/**
 	 * @inheritDoc
 	 */
 	static get pluginName() {
-		return 'clipboard/clipboard';
+		return 'clipboard';
 	}
 
 	/**

--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -32,7 +32,7 @@ import HtmlDataProcessor from '@ckeditor/ckeditor5-engine/src/dataprocessor/html
  *
  * 1. get HTML or plain text from the clipboard,
  * 2. prevent the default action of the native `paste` or `drop` event,
- * 3. fire {@link module:engine/view/document~Document#event:input} with a
+ * 3. fire {@link module:engine/view/document~Document#event:clipboardInput} with a
  * {@link module:clipboard/datatransfer~DataTransfer `dataTransfer`} property.
  * 4. fire {@link module:clipboard/clipboard~Clipboard#event:inputTransformation} with a `data` containing the clipboard data parsed to
  * a {@link module:engine/view/documentfragment~DocumentFragment view document fragment}.
@@ -42,13 +42,13 @@ import HtmlDataProcessor from '@ckeditor/ckeditor5-engine/src/dataprocessor/html
  * data from the clipboard (the {@link module:clipboard/datatransfer~DataTransfer `DataTransfer`}).
  * should plug a listener at this stage.
  *
- * ### On {@link module:engine/view/document~Document#event:input}
+ * ### On {@link module:engine/view/document~Document#event:clipboardInput}
  *
  * This action is performed by a low priority listener, so it can be overridden by a normal one.
  *
  * At this stage the dataTransfer object can be processed by the features, which want to transform the original dataTransform.
  *
- *		this.listenTo( editor.editing.view, 'input', ( evt, data ) => {
+ *		this.listenTo( editor.editing.view, 'clipboardInput', ( evt, data ) => {
  *			const content = customTransform( data.dataTransfer.get( 'text/html' ) );
  *			const transformedContent = transform( content );
  * 			data.dataTransfer.set( 'text/html', transformedContent );
@@ -132,7 +132,7 @@ export default class Clipboard extends Plugin {
 
 		// The clipboard paste pipeline.
 
-		this.listenTo( editingView, 'input', ( evt, data ) => {
+		this.listenTo( editingView, 'clipboardInput', ( evt, data ) => {
 			const dataTransfer = data.dataTransfer;
 			let content = '';
 

--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -17,7 +17,7 @@ import normalizeClipboardHtml from './utils/normalizeclipboarddata';
 import HtmlDataProcessor from '@ckeditor/ckeditor5-engine/src/dataprocessor/htmldataprocessor';
 
 /**
- * The clipboard feature. Currently, it's only responsible for intercepting the `paste` event and
+ * The clipboard feature. Currently, it's responsible for intercepting the `paste` and `drop` events and
  * passing the pasted content through the clipboard pipeline.
  *
  * ## Clipboard input pipeline
@@ -26,21 +26,28 @@ import HtmlDataProcessor from '@ckeditor/ckeditor5-engine/src/dataprocessor/html
  * before it gets inserted into the editor. The pipeline consists of two events on which
  * the features can listen in order to modify or totally override the default behavior.
  *
- * ### On {@link module:engine/view/document~Document#event:paste}
+ * ### On {@link module:engine/view/document~Document#event:paste} and {@link module:engine/view/document~Document#event:drop}
  *
  * The default action is to:
  *
  * 1. get HTML or plain text from the clipboard,
- * 2. prevent the default action of the native `paste` event,
- * 3. fire {@link module:engine/view/document~Document#event:clipboardInput} with the clipboard data parsed to
+ * 2. prevent the default action of the native `paste` or `drop` event,
+ * 3. fire {@link module:engine/view/document~Document#event:input} with a
+ * {@link module:clipboard/datatransfer~DataTransfer `dataTransfer`} property.
+ * 4. fire {@link module:clipboard/clipboard~Clipboard#event:inputTransformation} with a
+ * {@link module:clipboard/clipboard~ClipboardInputEventData `data`} containing the clipboard data parsed to
  * a {@link module:engine/view/documentfragment~DocumentFragment view document fragment}.
  *
- * This action is performed by a low priority listener, so it can be overridden by a normal one
+ * These action are performed by a low priority listeners, so they can be overridden by a normal ones
  * when a deeper change in pasting behavior is needed. For example, a feature which wants to differently read
  * data from the clipboard (the {@link module:clipboard/datatransfer~DataTransfer `DataTransfer`}).
  * should plug a listener at this stage.
  *
- * ### On {@link module:engine/view/document~Document#event:clipboardInput}
+ * ### On {@link module:engine/view/document~Document#event:input}
+ *
+ * TODO
+ *
+ * ### On {@link module:clipboard/clipboard~Clipboard#event:inputTransformation}
  *
  * The default action is to insert the content (`data.content`, represented by a
  * {@link module:engine/view/documentfragment~DocumentFragment}) to an editor if the data is not empty.
@@ -177,34 +184,28 @@ export default class Clipboard extends Plugin {
 }
 
 /**
- * Fired with a content which comes from the clipboard (was pasted or dropped) and
+ * Fired with a `dataTransfer`, which comes from the clipboard (was pasted or dropped) and
  * should be processed in order to be inserted into the editor.
  * It's part of the {@link module:clipboard/clipboard~Clipboard "clipboard pipeline"}.
  *
  * @see module:clipboard/clipboardobserver~ClipboardObserver
  * @see module:clipboard/clipboard~Clipboard
- * @event module:engine/view/document~Document#event:clipboardInput
- * @param {module:clipboard/clipboard~ClipboardInputEventData} data Event data.
+ * @event module:engine/view/document~Document#event:input
+ * @param {Object} data Event data.
+ * @param {module:clipboard/datatransfer~DataTransfer} data.dataTransfer Data transfer instance.
  */
 
 /**
- * The value of the {@link module:engine/view/document~Document#event:clipboardInput} event.
+ * Fired with a `content`, which comes from the clipboard (was pasted or dropped) and
+ * should be processed in order to be inserted into the editor.
+ * It's part of the {@link module:clipboard/clipboard~Clipboard "clipboard pipeline"}.
  *
- * @class module:clipboard/clipboard~ClipboardInputEventData
- */
-
-/**
- * Data transfer instance.
- *
- * @readonly
- * @member {module:clipboard/datatransfer~DataTransfer} module:clipboard/clipboard~ClipboardInputEventData#dataTransfer
- */
-
-/**
- * Content to be inserted into the editor. It can be modified by the event listeners.
- * Read more about the clipboard pipelines in {@link module:clipboard/clipboard~Clipboard}.
- *
- * @member {module:engine/view/documentfragment~DocumentFragment} module:clipboard/clipboard~ClipboardInputEventData#content
+ * @see module:clipboard/clipboardobserver~ClipboardObserver
+ * @see module:clipboard/clipboard~Clipboard
+ * @event module:clipboard/clipboard~Clipboard#event:inputTransformation
+ * @param {Object} data Event data.
+ * @param {module:engine/view/documentfragment~DocumentFragment} data.content Event data. Content to be inserted into the editor.
+ * It can be modified by the event listeners. Read more about the clipboard pipelines in {@link module:clipboard/clipboard~Clipboard}
  */
 
 /**

--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -51,7 +51,7 @@ import HtmlDataProcessor from '@ckeditor/ckeditor5-engine/src/dataprocessor/html
  *		this.listenTo( editor.editing.view, 'clipboardInput', ( evt, data ) => {
  *			const content = customTransform( data.dataTransfer.get( 'text/html' ) );
  *			const transformedContent = transform( content );
- * 			data.dataTransfer.set( 'text/html', transformedContent );
+ *			data.dataTransfer.set( 'text/html', transformedContent );
  *		} );
  *
  * ### On {@link module:clipboard/clipboard~Clipboard#event:inputTransformation}

--- a/src/clipboardobserver.js
+++ b/src/clipboardobserver.js
@@ -22,12 +22,12 @@ export default class ClipboardObserver extends DomEventObserver {
 	constructor( doc ) {
 		super( doc );
 
-		this.domEventType = [ 'paste', 'copy', 'cut' ];
+		this.domEventType = [ 'paste', 'copy', 'cut', 'drop' ];
 	}
 
 	onDomEvent( domEvent ) {
 		this.fire( domEvent.type, domEvent, {
-			dataTransfer: new DataTransfer( domEvent.clipboardData )
+			dataTransfer: new DataTransfer( domEvent.clipboardData ? domEvent.clipboardData : domEvent.dataTransfer )
 		} );
 	}
 }

--- a/src/clipboardobserver.js
+++ b/src/clipboardobserver.js
@@ -24,14 +24,14 @@ export default class ClipboardObserver extends DomEventObserver {
 
 		this.domEventType = [ 'paste', 'copy', 'cut', 'drop' ];
 
-		this.document.on( 'paste', _handleInput, { priority: 'low' } );
-		this.document.on( 'drop', _handleInput, { priority: 'low' } );
+		doc.on( 'paste', _handleInput, { priority: 'low' } );
+		doc.on( 'drop', _handleInput, { priority: 'low' } );
 
 		function _handleInput( evt, data ) {
 			// Prevent page refreshing.
 			data.preventDefault();
 
-			this.document.fire( 'input', { data: data.dataTransfer } );
+			doc.fire( 'input', { dataTransfer: data.dataTransfer } );
 		}
 	}
 

--- a/src/clipboardobserver.js
+++ b/src/clipboardobserver.js
@@ -23,6 +23,16 @@ export default class ClipboardObserver extends DomEventObserver {
 		super( doc );
 
 		this.domEventType = [ 'paste', 'copy', 'cut', 'drop' ];
+
+		this.document.on( 'paste', _handleInput, { priority: 'low' } );
+		this.document.on( 'drop', _handleInput, { priority: 'low' } );
+
+		function _handleInput( evt, data ) {
+			// Prevent page refreshing.
+			data.preventDefault();
+
+			this.document.fire( 'input', { data: data.dataTransfer } );
+		}
 	}
 
 	onDomEvent( domEvent ) {

--- a/src/clipboardobserver.js
+++ b/src/clipboardobserver.js
@@ -43,6 +43,20 @@ export default class ClipboardObserver extends DomEventObserver {
 }
 
 /**
+ * Fired when user dropped content into one of the editables.
+ *
+ * Introduced by {@link module:clipboard/clipboardobserver~ClipboardObserver}.
+ *
+ * Note that this event is not available by default. To make it available {@link module:clipboard/clipboardobserver~ClipboardObserver}
+ * needs to be added to {@link module:engine/view/document~Document} by the {@link module:engine/view/document~Document#addObserver} method.
+ * It's done by the {@link module:clipboard/clipboard~Clipboard} feature. If it's not loaded, it must be done manually.
+ *
+ * @see module:clipboard/clipboardobserver~ClipboardObserver
+ * @event module:engine/view/document~Document#event:drop
+ * @param {module:clipboard/clipboardobserver~ClipboardEventData} data Event data.
+ */
+
+/**
  * Fired when user pasted content into one of the editables.
  *
  * Introduced by {@link module:clipboard/clipboardobserver~ClipboardObserver}.

--- a/src/clipboardobserver.js
+++ b/src/clipboardobserver.js
@@ -24,14 +24,13 @@ export default class ClipboardObserver extends DomEventObserver {
 
 		this.domEventType = [ 'paste', 'copy', 'cut', 'drop' ];
 
-		doc.on( 'paste', _handleInput, { priority: 'low' } );
-		doc.on( 'drop', _handleInput, { priority: 'low' } );
+		this.listenTo( doc, 'paste', handleInput, { priority: 'low' } );
+		this.listenTo( doc, 'drop', handleInput, { priority: 'low' } );
 
-		function _handleInput( evt, data ) {
-			// Prevent page refreshing.
+		function handleInput( evt, data ) {
 			data.preventDefault();
 
-			doc.fire( 'input', { dataTransfer: data.dataTransfer } );
+			doc.fire( 'clipboardInput', { dataTransfer: data.dataTransfer } );
 		}
 	}
 

--- a/src/clipboardobserver.js
+++ b/src/clipboardobserver.js
@@ -43,6 +43,18 @@ export default class ClipboardObserver extends DomEventObserver {
 }
 
 /**
+ * Fired with a `dataTransfer`, which comes from the clipboard (was pasted or dropped) and
+ * should be processed in order to be inserted into the editor.
+ * It's part of the {@link module:clipboard/clipboard~Clipboard "clipboard pipeline"}.
+ *
+ * @see module:clipboard/clipboardobserver~ClipboardObserver
+ * @see module:clipboard/clipboard~Clipboard
+ * @event module:engine/view/document~Document#event:input
+ * @param {Object} data Event data.
+ * @param {module:clipboard/datatransfer~DataTransfer} data.dataTransfer Data transfer instance.
+ */
+
+/**
  * Fired when user dropped content into one of the editables.
  *
  * Introduced by {@link module:clipboard/clipboardobserver~ClipboardObserver}.

--- a/src/datatransfer.js
+++ b/src/datatransfer.js
@@ -42,4 +42,26 @@ export default class DataTransfer {
 	setData( type, data ) {
 		this._native.setData( type, data );
 	}
+
+	*getFiles() {
+		// DataTransfer.files and items are Array-like and might not have an iterable interface.
+		const files = this._native.files ? Array.from( this._native.files ) : [];
+		const items = this._native.items ? Array.from( this._native.items ) : [];
+
+		if ( files.length ) {
+			yield* files;
+		}
+		// // Chrome have empty DataTransfer.files, but let get files through the items interface.
+		else {
+			for ( const item of items ) {
+				if ( item.kind == 'file' ) {
+					yield item.getAsFile();
+				}
+			}
+		}
+	}
+
+	getTypes() {
+		return this._native.types;
+	}
 }

--- a/src/datatransfer.js
+++ b/src/datatransfer.js
@@ -19,6 +19,8 @@ export default class DataTransfer {
 		 * @member {DataTransfer} #_native
 		 */
 		this._native = nativeDataTransfer;
+
+		this.files = Array.from( this.getFiles() );
 	}
 
 	/**
@@ -43,7 +45,7 @@ export default class DataTransfer {
 		this._native.setData( type, data );
 	}
 
-	*getFiles() {
+	*_getFiles() {
 		// DataTransfer.files and items are Array-like and might not have an iterable interface.
 		const files = this._native.files ? Array.from( this._native.files ) : [];
 		const items = this._native.items ? Array.from( this._native.items ) : [];
@@ -61,7 +63,7 @@ export default class DataTransfer {
 		}
 	}
 
-	getTypes() {
+	get types() {
 		return this._native.types;
 	}
 }

--- a/src/datatransfer.js
+++ b/src/datatransfer.js
@@ -20,6 +20,12 @@ export default class DataTransfer {
 		 */
 		this._native = nativeDataTransfer;
 
+		/**
+		 * The array of files created from the native `DataTransfer#files` and `DataTransfer#items` objects.
+		 *
+		 * @public
+		 * @member {Array.<File>} #files
+		 */
 		this.files = Array.from( this._getFiles() );
 	}
 

--- a/src/datatransfer.js
+++ b/src/datatransfer.js
@@ -20,7 +20,7 @@ export default class DataTransfer {
 		 */
 		this._native = nativeDataTransfer;
 
-		this.files = Array.from( this.getFiles() );
+		this.files = Array.from( this._getFiles() );
 	}
 
 	/**

--- a/tests/clipboard.js
+++ b/tests/clipboard.js
@@ -41,11 +41,11 @@ describe( 'Clipboard feature', () => {
 
 	describe( 'clipboard paste pipeline', () => {
 		describe( 'takes HTML data from the dataTransfer', () => {
-			it( 'and fires the input event on the editingView', ( done ) => {
+			it( 'and fires the clipboardInput event on the editingView', ( done ) => {
 				const dataTransferMock = createDataTransfer( { 'text/html': '<p>x</p>', 'text/plain': 'y' } );
 				const preventDefaultSpy = sinon.spy();
 
-				editingView.on( 'input', ( evt, data ) => {
+				editingView.on( 'clipboardInput', ( evt, data ) => {
 					expect( preventDefaultSpy.calledOnce ).to.be.true;
 					expect( data.dataTransfer ).to.equal( dataTransferMock );
 
@@ -77,11 +77,11 @@ describe( 'Clipboard feature', () => {
 		} );
 
 		describe( 'takes plain text data from the dataTransfer if there is no HTML', () => {
-			it( 'and fires the input event on the editingView', ( done ) => {
+			it( 'and fires the clipboardInput event on the editingView', ( done ) => {
 				const dataTransferMock = createDataTransfer( { 'text/plain': 'x\n\ny  z' } );
 				const preventDefaultSpy = sinon.spy();
 
-				editingView.on( 'input', ( evt, data ) => {
+				editingView.on( 'clipboardInput', ( evt, data ) => {
 					expect( preventDefaultSpy.calledOnce ).to.be.true;
 					expect( data.dataTransfer ).to.equal( dataTransferMock );
 
@@ -117,7 +117,7 @@ describe( 'Clipboard feature', () => {
 			const preventDefaultSpy = sinon.spy();
 			const editorViewCalled = sinon.spy();
 
-			editingView.on( 'input', ( evt, data ) => {
+			editingView.on( 'clipboardInput', ( evt, data ) => {
 				expect( preventDefaultSpy.calledOnce ).to.be.true;
 
 				expect( data.dataTransfer ).to.equal( dataTransferMock );
@@ -148,7 +148,7 @@ describe( 'Clipboard feature', () => {
 				evt.stop();
 			} );
 
-			editingView.on( 'input', spy );
+			editingView.on( 'clipboardInput', spy );
 
 			editingView.fire( 'paste', {
 				dataTransfer: dataTransferMock,
@@ -190,7 +190,7 @@ describe( 'Clipboard feature', () => {
 			const dataTransferMock = createDataTransfer( { 'text/plain': '' } );
 			const spy = sinon.stub( editor.data, 'insertContent' );
 
-			editingView.fire( 'input', {
+			editingView.fire( 'clipboardInput', {
 				dataTransfer: dataTransferMock,
 				content: new ViewDocumentFragment()
 			} );
@@ -198,11 +198,11 @@ describe( 'Clipboard feature', () => {
 			expect( spy.callCount ).to.equal( 0 );
 		} );
 
-		it( 'uses low priority observer for the input event', () => {
+		it( 'uses low priority observer for the clipboardInput event', () => {
 			const dataTransferMock = createDataTransfer( { 'text/html': 'x' } );
 			const spy = sinon.stub( editor.data, 'insertContent' );
 
-			editingView.on( 'input', ( evt ) => {
+			editingView.on( 'clipboardInput', ( evt ) => {
 				evt.stop();
 			} );
 

--- a/tests/clipboard.js
+++ b/tests/clipboard.js
@@ -29,7 +29,7 @@ describe( 'Clipboard feature', () => {
 			.then( ( newEditor ) => {
 				editor = newEditor;
 				editingView = editor.editing.view;
-				clipboardPlugin = editor.plugins.get( 'clipboard' );
+				clipboardPlugin = editor.plugins.get( 'clipboard/clipboard' );
 			} );
 	} );
 

--- a/tests/clipboardobserver.js
+++ b/tests/clipboardobserver.js
@@ -18,11 +18,11 @@ describe( 'ClipboardObserver', () => {
 	} );
 
 	it( 'should define domEventType', () => {
-		expect( observer.domEventType ).to.deep.equal( [ 'paste', 'copy', 'cut' ] );
+		expect( observer.domEventType ).to.deep.equal( [ 'paste', 'copy', 'cut', 'drop' ] );
 	} );
 
 	describe( 'onDomEvent', () => {
-		it( 'should fire paste with the right event data', () => {
+		it.skip( 'should fire paste with the right event data', () => {
 			const spy = sinon.spy();
 			const dataTransfer = {
 				getData( type ) {

--- a/tests/clipboardobserver.js
+++ b/tests/clipboardobserver.js
@@ -22,26 +22,61 @@ describe( 'ClipboardObserver', () => {
 	} );
 
 	describe( 'onDomEvent', () => {
-		it.skip( 'should fire paste with the right event data', () => {
-			const spy = sinon.spy();
-			const dataTransfer = {
+		let pasteSpy, preventDefaultSpy;
+
+		function getDataTransfer() {
+			return {
 				getData( type ) {
 					return 'foo:' + type;
 				}
 			};
+		}
 
-			viewDocument.on( 'paste', spy );
+		beforeEach( () => {
+			pasteSpy = sinon.spy();
+			preventDefaultSpy = sinon.spy();
+		} );
 
-			observer.onDomEvent( { type: 'paste', target: document.body, clipboardData: dataTransfer } );
+		it( 'should fire paste with the right event data - clipboardData', () => {
+			const dataTransfer = getDataTransfer();
 
-			expect( spy.calledOnce ).to.be.true;
+			viewDocument.on( 'paste', pasteSpy );
 
-			const data = spy.args[ 0 ][ 1 ];
+			observer.onDomEvent( {
+				type: 'paste',
+				target: document.body,
+				clipboardData: dataTransfer,
+				preventDefault: preventDefaultSpy
+			} );
+
+			expect( pasteSpy.calledOnce ).to.be.true;
+
+			const data = pasteSpy.args[ 0 ][ 1 ];
 			expect( data.domTarget ).to.equal( document.body );
 			expect( data.dataTransfer ).to.be.instanceOf( DataTransfer );
 			expect( data.dataTransfer.getData( 'x/y' ) ).to.equal( 'foo:x/y' );
+			expect( preventDefaultSpy.calledOnce ).to.be.true;
 		} );
 
-		// If it fires paste it fires all the other events too.
+		it( 'should fire paste with the right event data - dataTransfer', () => {
+			const dataTransfer = getDataTransfer();
+
+			viewDocument.on( 'drop', pasteSpy );
+
+			observer.onDomEvent( {
+				type: 'drop',
+				target: document.body,
+				dataTransfer,
+				preventDefault: preventDefaultSpy
+			} );
+
+			expect( pasteSpy.calledOnce ).to.be.true;
+
+			const data = pasteSpy.args[ 0 ][ 1 ];
+			expect( data.domTarget ).to.equal( document.body );
+			expect( data.dataTransfer ).to.be.instanceOf( DataTransfer );
+			expect( data.dataTransfer.getData( 'x/y' ) ).to.equal( 'foo:x/y' );
+			expect( preventDefaultSpy.calledOnce ).to.be.true;
+		} );
 	} );
 } );

--- a/tests/datatransfer.js
+++ b/tests/datatransfer.js
@@ -6,7 +6,34 @@
 import DataTransfer from '../src/datatransfer';
 
 describe( 'DataTransfer', () => {
-	describe( 'getData', () => {
+	describe( 'constructor', () => {
+		it( 'should create files from the native files', () => {
+			const dt = new DataTransfer( {
+				files: {
+					0: 'file1',
+					1: 'file2',
+					length: 2
+				}
+			} );
+
+			expect( dt.files ).to.deep.equal( [ 'file1', 'file2' ] );
+		} );
+
+		it( 'should create files from the native items', () => {
+			const dt = new DataTransfer( {
+				items: {
+					0: { kind: 'file', getAsFile: () => 'file1' },
+					1: { kind: 'file', getAsFile: () => 'file2' },
+					2: { kind: 'someOtherKind' },
+					length: 3
+				},
+				files: []
+			} );
+
+			expect( dt.files ).to.deep.equal( [ 'file1', 'file2' ] );
+		} );
+	} );
+	describe( 'getData()', () => {
 		it( 'should return data from the native data transfer', () => {
 			const dt = new DataTransfer( {
 				getData( type ) {
@@ -18,7 +45,7 @@ describe( 'DataTransfer', () => {
 		} );
 	} );
 
-	describe( 'setData', () => {
+	describe( 'setData()', () => {
 		it( 'should return set data in the native data transfer', () => {
 			const spy = sinon.spy();
 			const dt = new DataTransfer( {
@@ -28,6 +55,16 @@ describe( 'DataTransfer', () => {
 			dt.setData( 'text/html', 'bar' );
 
 			expect( spy.calledWithExactly( 'text/html', 'bar' ) ).to.be.true;
+		} );
+	} );
+
+	describe( 'types', () => {
+		it( 'should return available types', () => {
+			const dt = new DataTransfer( {
+				types: [ 'text/html', 'text/plain' ]
+			} );
+
+			expect( dt.types ).to.deep.equal( [ 'text/html', 'text/plain' ] );
 		} );
 	} );
 } );

--- a/tests/manual/copycut.js
+++ b/tests/manual/copycut.js
@@ -36,6 +36,7 @@ ClassicEditor.create( document.querySelector( '#editor' ), {
 } )
 .then( editor => {
 	window.editor = editor;
+	const clipboard = editor.plugins.get( 'clipboard/clipboard' );
 
 	editor.editing.view.on( 'paste', ( evt, data ) => {
 		console.clear();
@@ -45,7 +46,7 @@ ClassicEditor.create( document.querySelector( '#editor' ), {
 	editor.editing.view.on( 'copy', onViewEvent, { priority: 'lowest' } );
 	editor.editing.view.on( 'cut', onViewEvent, { priority: 'lowest' } );
 
-	editor.editing.view.on( 'input', onPipelineEvent );
+	clipboard.on( 'inputTransformation', onPipelineEvent );
 	editor.editing.view.on( 'clipboardOutput', ( evt, data ) => {
 		console.clear();
 		onPipelineEvent( evt, data );

--- a/tests/manual/copycut.js
+++ b/tests/manual/copycut.js
@@ -45,7 +45,7 @@ ClassicEditor.create( document.querySelector( '#editor' ), {
 	editor.editing.view.on( 'copy', onViewEvent, { priority: 'lowest' } );
 	editor.editing.view.on( 'cut', onViewEvent, { priority: 'lowest' } );
 
-	editor.editing.view.on( 'clipboardInput', onPipelineEvent );
+	editor.editing.view.on( 'input', onPipelineEvent );
 	editor.editing.view.on( 'clipboardOutput', ( evt, data ) => {
 		console.clear();
 		onPipelineEvent( evt, data );

--- a/tests/manual/pasting.js
+++ b/tests/manual/pasting.js
@@ -46,7 +46,7 @@ ClassicEditor.create( document.querySelector( '#editor' ), {
 		console.log( 'text/plain\n', data.dataTransfer.getData( 'text/plain' ) );
 	} );
 
-	editor.editing.view.on( 'clipboardInput', ( evt, data ) => {
+	editor.editing.view.on( 'input', ( evt, data ) => {
 		console.log( '----- clipboardInput -----' );
 		console.log( 'stringify( data.content )\n', stringifyView( data.content ) );
 	} );

--- a/tests/manual/pasting.js
+++ b/tests/manual/pasting.js
@@ -36,6 +36,7 @@ ClassicEditor.create( document.querySelector( '#editor' ), {
 } )
 .then( editor => {
 	window.editor = editor;
+	const clipboard = editor.plugins.get( 'clipboard/clipboard' );
 
 	editor.editing.view.on( 'paste', ( evt, data ) => {
 		console.clear();
@@ -46,9 +47,9 @@ ClassicEditor.create( document.querySelector( '#editor' ), {
 		console.log( 'text/plain\n', data.dataTransfer.getData( 'text/plain' ) );
 	} );
 
-	editor.editing.view.on( 'input', ( evt, data ) => {
+	clipboard.on( 'inputTransformation', ( evt, data ) => {
 		console.log( '----- clipboardInput -----' );
-		console.log( 'stringify( data.content )\n', stringifyView( data.content ) );
+		console.log( 'stringify( data.dataTransfer )\n', stringifyView( data.content ) );
 	} );
 } )
 .catch( err => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Introduced `DataTransfer#files` property. Changed the `clipboardInput` event and added the `inputTranformation` event. Closes #16.