### PR TITLE
Added: text/plain support for copy/cut.

### DIFF
--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -13,6 +13,7 @@ import ClipboardObserver from './clipboardobserver';
 
 import plainTextToHtml from './utils/plaintexttohtml';
 import normalizeClipboardHtml from './utils/normalizeclipboarddata';
+import viewToPlainText from './utils/viewtoplaintext.js';
 
 import HtmlDataProcessor from '@ckeditor/ckeditor5-engine/src/dataprocessor/htmldataprocessor';
 
@@ -179,6 +180,7 @@ export default class Clipboard extends Plugin {
 		this.listenTo( editingView, 'clipboardOutput', ( evt, data ) => {
 			if ( !data.content.isEmpty ) {
 				data.dataTransfer.setData( 'text/html', this._htmlDataProcessor.toData( data.content ) );
+				data.dataTransfer.setData( 'text/plain', viewToPlainText( data.content ) );
 			}
 
 			if ( data.method == 'cut' ) {

--- a/src/utils/viewtoplaintext.js
+++ b/src/utils/viewtoplaintext.js
@@ -1,0 +1,53 @@
+/**
+ * @license Copyright (c) 2003-2017, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/**
+ * @module clipboard/utils/viewtoplaintext
+ */
+
+/**
+ * Deeply converts {@link module:engine/model/view/item view item} to plain text.
+ *
+ * @param {module:engine/model/view/item} viewItem View item to convert.
+ * @returns {String} Plain text representation of `viewItem`.
+ */
+export default function viewToPlainText( viewItem ) {
+	let text = '';
+
+	if ( viewItem.is( 'text' ) || viewItem.is( 'textProxy' ) ) {
+		// If item is `Text` or `TextProxy` simple take its text data.
+		text = viewItem.data;
+	} else if ( viewItem.is( 'img' ) && viewItem.hasAttribute( 'alt' ) ) {
+		// Special case for images - use alt attribute if it is provided.
+		text = viewItem.getAttribute( 'alt' );
+	} else {
+		// Other elements are document fragments, attribute elements or container elements.
+		// They don't have their own text value, so convert their children.
+		let prev = null;
+
+		for ( let child of viewItem.getChildren() ) {
+			const childText = viewToPlainText( child );
+
+			// Separate container element children with one or more new-line characters.
+			if ( prev && ( prev.is( 'containerElement' ) || child.is( 'containerElement' ) ) ) {
+				if ( smallPaddingElements.includes( prev.name ) || smallPaddingElements.includes( child.name ) ) {
+					text += '\n';
+				} else {
+					text += '\n\n';
+				}
+			}
+
+			text += childText;
+			prev = child;
+		}
+	}
+
+	return text;
+}
+
+// Elements which should not have empty-line padding.
+// Most `view.ContainerElement` want to be separate by new-line, but some are creating one structure
+// together (like `<li>`) so it is better to separate them by only one "\n".
+const smallPaddingElements = [ 'figcaption', 'li' ];

--- a/tests/manual/copycut.md
+++ b/tests/manual/copycut.md
@@ -2,4 +2,5 @@
 
 Play with copy and cut. Paste copied content.
 
-Compare the results with the native editable. Don't expect that they behave identically.
+Compare the results with the native editable. Don't expect that they behave identically. Check plain text pasting
+(for example paste editor content to code editor).

--- a/tests/utils/viewtoplaintext.js
+++ b/tests/utils/viewtoplaintext.js
@@ -1,0 +1,72 @@
+/**
+ * @license Copyright (c) 2003-2017, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import viewToPlainText from '../../src/utils/viewtoplaintext';
+
+import { parse as parseView } from '@ckeditor/ckeditor5-engine/src/dev-utils/view';
+
+describe( 'viewToPlainText', () => {
+	function test( viewString, expectedText ) {
+		const view = parseView( viewString );
+		const text = viewToPlainText( view );
+
+		expect( text ).to.equal( expectedText );
+	}
+
+	it( 'should output text contents of given view', () => {
+		test(
+			'<container:p>Foo<strong>Bar</strong>Xyz</container:p>',
+			'FooBarXyz'
+		);
+	} );
+
+	it( 'should put empty line between container elements', () => {
+		test(
+			'<container:h1>Header</container:h1>' +
+			'<container:p>Foo</container:p>' +
+			'<container:p>Bar</container:p>' +
+			'Abc' +
+			'<container:div>Xyz</container:div>',
+
+			'Header\n\nFoo\n\nBar\n\nAbc\n\nXyz'
+		);
+	} );
+
+	it( 'should output alt attribute of image elements', () => {
+		test(
+			'<container:p>Foo</container:p>' +
+			'<img src="foo.jpg" alt="Alt" />',
+
+			'Foo\n\nAlt'
+		);
+	} );
+
+	it( 'should not put empty line after li (if not needed)', () => {
+		test(
+			'<container:p>Foo</container:p>' +
+			'<container:ul>' +
+				'<container:li>A</container:li>' +
+				'<container:li>B</container:li>' +
+				'<container:li>C</container:li>' +
+			'</container:ul>' +
+			'<container:p>Bar</container:p>',
+
+			'Foo\n\nA\nB\nC\n\nBar'
+		);
+	} );
+
+	it( 'should not put empty line before/after figcaption (if not needed)', () => {
+		test(
+			'<container:p>Foo</container:p>' +
+			'<container:figure>' +
+				'<img src="foo.jpg" alt="Alt" />' +
+				'<container:figcaption>Caption</container:figcaption>' +
+			'</container:figure>' +
+			'<container:p>Bar</container:p>',
+
+			'Foo\n\nAlt\nCaption\n\nBar'
+		);
+	} );
+} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Plain text data is now available in clipboard when copying or cutting editor contents. Closes #11.