### PR TITLE
Disabled pasting and cutting when editor is read-only.

### DIFF
--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -134,6 +134,12 @@ export default class Clipboard extends Plugin {
 		// The clipboard paste pipeline.
 
 		this.listenTo( editingView, 'clipboardInput', ( evt, data ) => {
+			// Pasting and dropping is disabled when editor is read-only.
+			// See: https://github.com/ckeditor/ckeditor5-clipboard/issues/26.
+			if ( editor.isReadOnly ) {
+				return;
+			}
+
 			const dataTransfer = data.dataTransfer;
 			let content = '';
 

--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -165,14 +165,14 @@ export default class Clipboard extends Plugin {
 
 		// The clipboard copy/cut pipeline.
 
-		const onCopyCut = ( evt, data ) => {
+		function onCopyCut( evt, data ) {
 			const dataTransfer = data.dataTransfer;
 			const content = editor.data.toView( editor.data.getSelectedContent( doc.selection ) );
 
 			data.preventDefault();
 
 			editingView.fire( 'clipboardOutput', { dataTransfer, content, method: evt.name } );
-		};
+		}
 
 		this.listenTo( editingView, 'copy', onCopyCut, { priority: 'low' } );
 		this.listenTo( editingView, 'cut', onCopyCut, { priority: 'low' } );

--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -181,7 +181,15 @@ export default class Clipboard extends Plugin {
 		}
 
 		this.listenTo( editingView, 'copy', onCopyCut, { priority: 'low' } );
-		this.listenTo( editingView, 'cut', onCopyCut, { priority: 'low' } );
+		this.listenTo( editingView, 'cut', ( evt, data ) => {
+			// Cutting is disabled when editor is read-only.
+			// See: https://github.com/ckeditor/ckeditor5-clipboard/issues/26.
+			if ( editor.isReadOnly ) {
+				data.preventDefault();
+			} else {
+				onCopyCut( evt, data );
+			}
+		}, { priority: 'low' } );
 
 		this.listenTo( editingView, 'clipboardOutput', ( evt, data ) => {
 			if ( !data.content.isEmpty ) {

--- a/tests/clipboard.js
+++ b/tests/clipboard.js
@@ -174,6 +174,20 @@ describe( 'Clipboard feature', () => {
 			expect( stringifyModel( spy.args[ 0 ][ 0 ] ) ).to.equal( '<paragraph>x</paragraph>' );
 		} );
 
+		it( 'do not insert content when editor is read-only', () => {
+			const dataTransferMock = createDataTransfer( { 'text/html': '<p>x</p>', 'text/plain': 'y' } );
+			const spy = sinon.stub( editor.data, 'insertContent' );
+
+			editor.isReadOnly = true;
+
+			editingView.fire( 'paste', {
+				dataTransfer: dataTransferMock,
+				preventDefault() {}
+			} );
+
+			sinon.assert.notCalled( spy );
+		} );
+
 		it( 'converts content in an "all allowed" context', () => {
 			// It's enough if we check this here with a text node and paragraph because if the conversion was made
 			// in a normal root, then text or paragraph wouldn't be allowed here.

--- a/tests/clipboard.js
+++ b/tests/clipboard.js
@@ -283,6 +283,25 @@ describe( 'Clipboard feature', () => {
 			} );
 		} );
 
+		it( 'not fires clipboardOutput and preventDefault event for cut when editor is read-only', () => {
+			const dataTransferMock = createDataTransfer();
+			const preventDefaultSpy = sinon.spy();
+			const spy = sinon.spy();
+
+			setModelData( editor.document, '<paragraph>a[bc</paragraph><paragraph>de]f</paragraph>' );
+			editor.isReadOnly = true;
+
+			editingView.on( 'clipboardOutput', spy );
+
+			editingView.fire( 'cut', {
+				dataTransfer: dataTransferMock,
+				preventDefault: preventDefaultSpy
+			} );
+
+			sinon.assert.notCalled( spy );
+			sinon.assert.calledOnce( preventDefaultSpy );
+		} );
+
 		it( 'uses low priority observer for the copy event', () => {
 			const dataTransferMock = createDataTransfer();
 			const spy = sinon.spy();


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Disable pasting and cutting when an editor is read-only. Closes #26.