### PR TITLE
T/29: Support for drop positions

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,12 +13,8 @@
     "@ckeditor/ckeditor5-block-quote": "^0.1.1",
     "@ckeditor/ckeditor5-editor-classic": "^0.7.3",
     "@ckeditor/ckeditor5-paragraph": "^0.8.0",
-    "@ckeditor/ckeditor5-enter": "^0.9.1",
-    "@ckeditor/ckeditor5-heading": "^0.9.1",
+    "@ckeditor/ckeditor5-presets": "^0.2.2",
     "@ckeditor/ckeditor5-link": "^0.7.0",
-    "@ckeditor/ckeditor5-list": "^0.6.1",
-    "@ckeditor/ckeditor5-typing": "^0.9.1",
-    "@ckeditor/ckeditor5-undo": "^0.8.1",
     "eslint-config-ckeditor5": "^1.0.0",
     "gulp": "^3.9.1",
     "guppy-pre-commit": "^0.4.0"

--- a/src/clipboardobserver.js
+++ b/src/clipboardobserver.js
@@ -77,16 +77,25 @@ function getDropViewRange( doc, domEvent ) {
 }
 
 /**
- * Fired with a `dataTransfer` which comes from the clipboard (was {@link module:engine/view/document~Document#event:paste pasted}
- * or {@link module:engine/view/document~Document#event:drop dropped}) and
- * should be processed in order to be inserted into the editor.
+ * Fired as a continuation of {@link #event:paste} amd {@link #event:drop} events.
  * It's part of the {@link module:clipboard/clipboard~Clipboard "clipboard pipeline"}.
+ *
+ * Fired with a `dataTransfer` which comes from the clipboard and which content should be processed
+ * and inserted into the editor.
+ *
+ * Note that this event is not available by default. To make it available {@link module:clipboard/clipboardobserver~ClipboardObserver}
+ * needs to be added to {@link module:engine/view/document~Document} by the {@link module:engine/view/document~Document#addObserver} method.
+ * It's done by the {@link module:clipboard/clipboard~Clipboard} feature. If it's not loaded, it must be done manually.
  *
  * @see module:clipboard/clipboardobserver~ClipboardObserver
  * @see module:clipboard/clipboard~Clipboard
  * @event module:engine/view/document~Document#event:clipboardInput
  * @param {Object} data Event data.
  * @param {module:clipboard/datatransfer~DataTransfer} data.dataTransfer Data transfer instance.
+ * @param {Array.<module:engine/view/range~Range>} data.targetRanges Ranges which are the target of the operation
+ * (usually – into which the content should be inserted).
+ * If clipboard input was triggered by a paste operation, then these are the selection ranges. If by a drop operation,
+ * then it's the drop position (which can be different than the selection at the moment of drop).
  */
 
 /**
@@ -98,9 +107,10 @@ function getDropViewRange( doc, domEvent ) {
  * needs to be added to {@link module:engine/view/document~Document} by the {@link module:engine/view/document~Document#addObserver} method.
  * It's done by the {@link module:clipboard/clipboard~Clipboard} feature. If it's not loaded, it must be done manually.
  *
- * @see module:clipboard/clipboardobserver~ClipboardObserver
+ * @see module:engine/view/document~Document#event:clipboardInput
  * @event module:engine/view/document~Document#event:drop
  * @param {module:clipboard/clipboardobserver~ClipboardEventData} data Event data.
+ * @param {module:engine/view/range~Range} dropRange The position into which the content is dropped.
  */
 
 /**
@@ -112,7 +122,7 @@ function getDropViewRange( doc, domEvent ) {
  * needs to be added to {@link module:engine/view/document~Document} by the {@link module:engine/view/document~Document#addObserver} method.
  * It's done by the {@link module:clipboard/clipboard~Clipboard} feature. If it's not loaded, it must be done manually.
  *
- * @see module:clipboard/clipboardobserver~ClipboardObserver
+ * @see module:engine/view/document~Document#event:clipboardInput
  * @event module:engine/view/document~Document#event:paste
  * @param {module:clipboard/clipboardobserver~ClipboardEventData} data Event data.
  */

--- a/src/clipboardobserver.js
+++ b/src/clipboardobserver.js
@@ -77,7 +77,7 @@ function getDropViewRange( doc, domEvent ) {
 }
 
 /**
- * Fired as a continuation of {@link #event:paste} amd {@link #event:drop} events.
+ * Fired as a continuation of {@link #event:paste} and {@link #event:drop} events.
  * It's part of the {@link module:clipboard/clipboard~Clipboard "clipboard pipeline"}.
  *
  * Fired with a `dataTransfer` which comes from the clipboard and which content should be processed

--- a/tests/clipboardobserver.js
+++ b/tests/clipboardobserver.js
@@ -6,77 +6,238 @@
 /* globals document */
 
 import ClipboardObserver from '../src/clipboardobserver';
-import ViewDocument from '@ckeditor/ckeditor5-engine/src/view/document';
+import Document from '@ckeditor/ckeditor5-engine/src/view/document';
+import Element from '@ckeditor/ckeditor5-engine/src/view/element';
+import Range from '@ckeditor/ckeditor5-engine/src/view/range';
+import Position from '@ckeditor/ckeditor5-engine/src/view/position';
 import DataTransfer from '../src/datatransfer';
 
 describe( 'ClipboardObserver', () => {
-	let viewDocument, observer;
+	let doc, observer, root, el, range, eventSpy, preventDefaultSpy;
 
 	beforeEach( () => {
-		viewDocument = new ViewDocument();
-		observer = viewDocument.addObserver( ClipboardObserver );
+		doc = new Document();
+		root = doc.createRoot( 'div' );
+
+		// Create view and DOM structures.
+		el = new Element( 'p' );
+		root.appendChildren( el );
+		doc.domConverter.viewToDom( root, document, { withChildren: true, bind: true } );
+
+		doc.selection.collapse( el );
+		range = new Range( new Position( root, 1 ) );
+		// Just making sure that the following tests will check anything.
+		expect( range.isEqual( doc.selection.getFirstRange() ) ).to.be.false;
+
+		observer = doc.addObserver( ClipboardObserver );
+
+		eventSpy = sinon.spy();
+		preventDefaultSpy = sinon.spy();
 	} );
 
 	it( 'should define domEventType', () => {
 		expect( observer.domEventType ).to.deep.equal( [ 'paste', 'copy', 'cut', 'drop' ] );
 	} );
 
-	describe( 'onDomEvent', () => {
-		let pasteSpy, preventDefaultSpy;
+	describe( 'paste event', () => {
+		it( 'should be fired with the right event data', () => {
+			const dataTransfer = mockDomDataTransfer();
+			const targetElement = mockDomTargetElement( {} );
 
-		function getDataTransfer() {
-			return {
-				getData( type ) {
-					return 'foo:' + type;
-				}
-			};
-		}
-
-		beforeEach( () => {
-			pasteSpy = sinon.spy();
-			preventDefaultSpy = sinon.spy();
-		} );
-
-		it( 'should fire paste with the right event data - clipboardData', () => {
-			const dataTransfer = getDataTransfer();
-
-			viewDocument.on( 'paste', pasteSpy );
+			doc.on( 'paste', eventSpy );
 
 			observer.onDomEvent( {
 				type: 'paste',
-				target: document.body,
+				target: targetElement,
 				clipboardData: dataTransfer,
 				preventDefault: preventDefaultSpy
 			} );
 
-			expect( pasteSpy.calledOnce ).to.be.true;
+			expect( eventSpy.calledOnce ).to.be.true;
 
-			const data = pasteSpy.args[ 0 ][ 1 ];
-			expect( data.domTarget ).to.equal( document.body );
+			const data = eventSpy.args[ 0 ][ 1 ];
+
+			expect( data.domTarget ).to.equal( targetElement );
+
 			expect( data.dataTransfer ).to.be.instanceOf( DataTransfer );
 			expect( data.dataTransfer.getData( 'x/y' ) ).to.equal( 'foo:x/y' );
+
 			expect( preventDefaultSpy.calledOnce ).to.be.true;
 		} );
+	} );
 
-		it( 'should fire paste with the right event data - dataTransfer', () => {
-			const dataTransfer = getDataTransfer();
+	describe( 'drop event', () => {
+		it( 'should be fired with the right event data - basics', () => {
+			const dataTransfer = mockDomDataTransfer();
+			const targetElement = mockDomTargetElement( {} );
 
-			viewDocument.on( 'drop', pasteSpy );
+			doc.on( 'drop', eventSpy );
 
 			observer.onDomEvent( {
 				type: 'drop',
-				target: document.body,
+				target: targetElement,
 				dataTransfer,
 				preventDefault: preventDefaultSpy
 			} );
 
-			expect( pasteSpy.calledOnce ).to.be.true;
+			expect( eventSpy.calledOnce ).to.be.true;
 
-			const data = pasteSpy.args[ 0 ][ 1 ];
-			expect( data.domTarget ).to.equal( document.body );
+			const data = eventSpy.args[ 0 ][ 1 ];
+
+			expect( data.domTarget ).to.equal( targetElement );
+
 			expect( data.dataTransfer ).to.be.instanceOf( DataTransfer );
 			expect( data.dataTransfer.getData( 'x/y' ) ).to.equal( 'foo:x/y' );
+
+			expect( data.dropRange.isEqual( doc.selection.getFirstRange() ) ).to.be.true;
+
 			expect( preventDefaultSpy.calledOnce ).to.be.true;
+		} );
+
+		it( 'should be fired with the right event data – dropRange (when no info about it in the drop event)', () => {
+			const dataTransfer = mockDomDataTransfer();
+			const targetElement = mockDomTargetElement( {} );
+
+			doc.on( 'drop', eventSpy );
+
+			observer.onDomEvent( {
+				type: 'drop',
+				target: targetElement,
+				dataTransfer,
+				preventDefault() {}
+			} );
+
+			expect( eventSpy.calledOnce ).to.be.true;
+
+			const data = eventSpy.args[ 0 ][ 1 ];
+
+			expect( data.dropRange.isEqual( doc.selection.getFirstRange() ) ).to.be.true;
+		} );
+
+		it( 'should be fired with the right event data – dropRange (when document.caretRangeFromPoint present)', () => {
+			let caretRangeFromPointCalledWith;
+
+			const domRange = doc.domConverter.viewRangeToDom( range );
+			const dataTransfer = mockDomDataTransfer();
+			const targetElement = mockDomTargetElement( {
+				caretRangeFromPoint( x, y ) {
+					caretRangeFromPointCalledWith = [ x, y ];
+
+					return domRange;
+				}
+			} );
+
+			doc.on( 'drop', eventSpy );
+
+			observer.onDomEvent( {
+				type: 'drop',
+				target: targetElement,
+				dataTransfer,
+				clientX: 10,
+				clientY: 20,
+				preventDefault() {}
+			} );
+
+			expect( eventSpy.calledOnce ).to.be.true;
+
+			const data = eventSpy.args[ 0 ][ 1 ];
+
+			expect( data.dropRange.isEqual( range ) ).to.be.true;
+			expect( caretRangeFromPointCalledWith ).to.deep.equal( [ 10, 20 ] );
+		} );
+
+		it( 'should be fired with the right event data – dropRange (when evt.rangeParent|Offset present)', () => {
+			const domRange = doc.domConverter.viewRangeToDom( range );
+			const dataTransfer = mockDomDataTransfer();
+			const targetElement = mockDomTargetElement( {
+				createRange() {
+					return document.createRange();
+				}
+			} );
+
+			doc.on( 'drop', eventSpy );
+
+			observer.onDomEvent( {
+				type: 'drop',
+				target: targetElement,
+				dataTransfer,
+				rangeParent: domRange.startContainer,
+				rangeOffset: domRange.startOffset,
+				preventDefault() {}
+			} );
+
+			expect( eventSpy.calledOnce ).to.be.true;
+
+			const data = eventSpy.args[ 0 ][ 1 ];
+
+			expect( data.dropRange.isEqual( range ) ).to.be.true;
+		} );
+	} );
+
+	describe( 'clipboardInput event', () => {
+		it( 'should be fired on paste', () => {
+			const dataTransfer = new DataTransfer( mockDomDataTransfer() );
+			const normalPrioritySpy = sinon.spy();
+
+			doc.on( 'clipboardInput', eventSpy );
+			doc.on( 'paste', normalPrioritySpy );
+
+			doc.fire( 'paste', {
+				dataTransfer,
+				preventDefault: preventDefaultSpy
+			} );
+
+			expect( eventSpy.calledOnce ).to.be.true;
+			expect( preventDefaultSpy.calledOnce ).to.be.true;
+
+			const data = eventSpy.args[ 0 ][ 1 ];
+			expect( data.dataTransfer ).to.equal( dataTransfer );
+
+			expect( data.targetRanges ).to.have.length( 1 );
+			expect( data.targetRanges[ 0 ].isEqual( doc.selection.getFirstRange() ) ).to.be.true;
+
+			expect( sinon.assert.callOrder( normalPrioritySpy, eventSpy ) );
+		} );
+
+		it( 'should be fired on drop', () => {
+			const dataTransfer = new DataTransfer( mockDomDataTransfer() );
+			const normalPrioritySpy = sinon.spy();
+
+			doc.on( 'clipboardInput', eventSpy );
+			doc.on( 'drop', normalPrioritySpy );
+
+			doc.fire( 'drop', {
+				dataTransfer,
+				preventDefault: preventDefaultSpy,
+				dropRange: range
+			} );
+
+			expect( eventSpy.calledOnce ).to.be.true;
+			expect( preventDefaultSpy.calledOnce ).to.be.true;
+
+			const data = eventSpy.args[ 0 ][ 1 ];
+			expect( data.dataTransfer ).to.equal( dataTransfer );
+
+			expect( data.targetRanges ).to.have.length( 1 );
+			expect( data.targetRanges[ 0 ].isEqual( range ) ).to.be.true;
+
+			expect( sinon.assert.callOrder( normalPrioritySpy, eventSpy ) );
 		} );
 	} );
 } );
+
+// Returns a super simple mock of HTMLElement (we use only ownerDocument from it).
+function mockDomTargetElement( documentMock ) {
+	return {
+		ownerDocument: documentMock
+	};
+}
+
+function mockDomDataTransfer() {
+	return {
+		files: [],
+		getData( type ) {
+			return 'foo:' + type;
+		}
+	};
+}

--- a/tests/manual/copycut.js
+++ b/tests/manual/copycut.js
@@ -6,32 +6,12 @@
 /* globals console, window, document */
 
 import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
-import Typing from '@ckeditor/ckeditor5-typing/src/typing';
-import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
-import Undo from '@ckeditor/ckeditor5-undo/src/undo';
-import Enter from '@ckeditor/ckeditor5-enter/src/enter';
-import Clipboard from '../../src/clipboard';
-import Link from '@ckeditor/ckeditor5-link/src/link';
-import List from '@ckeditor/ckeditor5-list/src/list';
-import Heading from '@ckeditor/ckeditor5-heading/src/heading';
-import Bold from '@ckeditor/ckeditor5-basic-styles/src/bold';
-import Italic from '@ckeditor/ckeditor5-basic-styles/src/italic';
+import ArticlePreset from '@ckeditor/ckeditor5-presets/src/article';
 
 import { stringify as stringifyView } from '@ckeditor/ckeditor5-engine/src/dev-utils/view';
 
 ClassicEditor.create( document.querySelector( '#editor' ), {
-	plugins: [
-		Typing,
-		Paragraph,
-		Undo,
-		Enter,
-		Clipboard,
-		Link,
-		List,
-		Heading,
-		Bold,
-		Italic
-	],
+	plugins: [ ArticlePreset ],
 	toolbar: [ 'headings', 'bold', 'italic', 'link', 'bulletedList', 'numberedList', 'undo', 'redo' ]
 } )
 .then( editor => {

--- a/tests/manual/dropping.html
+++ b/tests/manual/dropping.html
@@ -1,0 +1,39 @@
+<div id="editor">
+	<h2>About CKEditor&nbsp;5, v0.3.0</h2>
+
+	<p>This is the <a href="http://ckeditor.com/blog/Third-Developer-Preview-of-CKEditor-5-Available">third developer preview</a> of <a href="https://ckeditor5.github.io">CKEditor&nbsp;5</a>.</p>
+
+	<p>After 2 years of work, building the next generation editor from scratch and closing over 670 tickets, we created a highly <strong>extensible and flexible architecture</strong> which consists of an <strong>amazing editing framework</strong> and <strong>editing solutions</strong> that will be built on top of it.</p>
+
+	<h3>Notes</h3>
+
+	<p><a href="https://ckeditor5.github.io">CKEditor&nbsp;5</a> is <i>under heavy development</i> and this demo is not production-ready software. For example:</p>
+
+	<ul>
+		<li><strong>only Chrome, Opera and Safari are supported</strong>,</li>
+		<li>Firefox requires enabling the <a href="https://developer.mozilla.org/en-US/docs/Web/API/Document/onselectionchange">&ldquo;dom.select_events.enabled&rdquo;</a> option,</li>
+		<li><a href="https://github.com/ckeditor/ckeditor5/issues/342">support for pasting</a> is under development.</li>
+	</ul>
+
+	<p>It has <em>bugs</em> that we are aware of – and that we will be working on in the next few iterations of the project. Stay tuned for some updates soon!</p>
+</div>
+
+<h2 style="margin-top: 100px">Some rich content to copy</h2>
+
+<p>Copy also this content to check how pasting from outside of the editor works. Feel free to also use content from other websites.</p>
+
+<p>This is the <a href="http://ckeditor.com/blog/Third-Developer-Preview-of-CKEditor-5-Available">third developer preview</a> of <strong>CKEditor&nbsp;5</strong>.</p>
+
+<p>After 2 years of work, building the next generation editor from scratch and closing over 670 tickets, we created a highly <strong>extensible and flexible architecture</strong> which consists of an <strong>amazing editing framework</strong> and <strong>editing solutions</strong> that will be built on top of it.</p>
+
+<h3>Notes</h3>
+
+<p><a href="https://ckeditor5.github.io">CKEditor&nbsp;5</a> is <i>under heavy development</i> and this demo is not production-ready software. For example:</p>
+
+<ul>
+	<li><strong>only Chrome, Opera and Safari are supported</strong>,</li>
+	<li>Firefox requires enabling the <a href="https://developer.mozilla.org/en-US/docs/Web/API/Document/onselectionchange">&ldquo;dom.select_events.enabled&rdquo;</a> option,</li>
+	<li><a href="https://github.com/ckeditor/ckeditor5/issues/342">support for pasting</a> is under development.</li>
+</ul>
+
+<p>It has <em>bugs</em> that we are aware of – and that we will be working on in the next few iterations of the project. Stay tuned for some updates soon!</p>

--- a/tests/manual/dropping.js
+++ b/tests/manual/dropping.js
@@ -1,0 +1,50 @@
+/**
+ * @license Copyright (c) 2003-2017, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/* globals console, window, document */
+
+import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
+import ArticlePreset from '@ckeditor/ckeditor5-presets/src/article';
+
+import Text from '@ckeditor/ckeditor5-engine/src/model/text';
+import Selection from '@ckeditor/ckeditor5-engine/src/model/selection';
+
+// import { stringify as stringifyView } from '@ckeditor/ckeditor5-engine/src/dev-utils/view';
+
+ClassicEditor.create( document.querySelector( '#editor' ), {
+	plugins: [ ArticlePreset ],
+	toolbar: [ 'headings', 'bold', 'italic', 'link', 'bulletedList', 'numberedList', 'undo', 'redo' ]
+} )
+.then( editor => {
+	window.editor = editor;
+	// const clipboard = editor.plugins.get( 'Clipboard' );
+
+	editor.editing.view.on( 'drop', ( evt, data ) => {
+		console.clear();
+
+		console.log( '----- drop -----' );
+		console.log( data );
+		console.log( 'text/html\n', data.dataTransfer.getData( 'text/html' ) );
+		console.log( 'text/plain\n', data.dataTransfer.getData( 'text/plain' ) );
+
+		data.preventDefault();
+		evt.stop();
+
+		editor.document.enqueueChanges( () => {
+			const insertAtSelection = new Selection( [ editor.editing.mapper.toModelRange( data.dropRange ) ] );
+			editor.data.insertContent( new Text( '@' ), insertAtSelection );
+			editor.document.selection.setTo( insertAtSelection );
+		} );
+	} );
+
+	// Waiting until a real dropping support...
+	// clipboard.on( 'inputTransformation', ( evt, data ) => {
+	// 	console.log( '----- clipboardInput -----' );
+	// 	console.log( 'stringify( data.dataTransfer )\n', stringifyView( data.content ) );
+	// } );
+} )
+.catch( err => {
+	console.error( err.stack );
+} );

--- a/tests/manual/dropping.md
+++ b/tests/manual/dropping.md
@@ -1,0 +1,11 @@
+## Dropping
+
+**Note:** There's no real drag&drop support yet. This test is only supposed to check if the drop position is calculated correctly.
+
+Expected: At the precise drop position (where you see the caret before releasing the mouse button) a "@" should be inserted.
+
+Notes:
+
+* It may all not work in Edge (because it's focused on file support now).
+* Drop position is not the same as selection before drop (which is not that aprarent if you drop something from outside but it's obvious if you d&d content within the editor).
+* It's a known bug that after dropping content from outside the editor there's no focus in the editor.

--- a/tests/manual/pasting.js
+++ b/tests/manual/pasting.js
@@ -6,32 +6,12 @@
 /* globals console, window, document */
 
 import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
-import Typing from '@ckeditor/ckeditor5-typing/src/typing';
-import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
-import Undo from '@ckeditor/ckeditor5-undo/src/undo';
-import Enter from '@ckeditor/ckeditor5-enter/src/enter';
-import Clipboard from '../../src/clipboard';
-import Link from '@ckeditor/ckeditor5-link/src/link';
-import List from '@ckeditor/ckeditor5-list/src/list';
-import Heading from '@ckeditor/ckeditor5-heading/src/heading';
-import Bold from '@ckeditor/ckeditor5-basic-styles/src/bold';
-import Italic from '@ckeditor/ckeditor5-basic-styles/src/italic';
+import ArticlePreset from '@ckeditor/ckeditor5-presets/src/article';
 
 import { stringify as stringifyView } from '@ckeditor/ckeditor5-engine/src/dev-utils/view';
 
 ClassicEditor.create( document.querySelector( '#editor' ), {
-	plugins: [
-		Typing,
-		Paragraph,
-		Undo,
-		Enter,
-		Clipboard,
-		Link,
-		List,
-		Heading,
-		Bold,
-		Italic
-	],
+	plugins: [ ArticlePreset ],
 	toolbar: [ 'headings', 'bold', 'italic', 'link', 'bulletedList', 'numberedList', 'undo', 'redo' ]
 } )
 .then( editor => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Added `dropRange` to the `drop` event and `targetRanges` to the `clipboardInput` event. Closes #29.

---

### Additional information

As you may notice the full d&d support misses just two things now – using the actual drop position (and not the selection) at the end of clipboard input pipeline. Right now the selection is used... so you don't see any changes when d&ding within the editor. The second thing is deleting the dragged content from its original position. But I didn't want to make this PR any bigger now, so this will come some other day.

Also, there's Edge support which I didn't check at all after @Mgsy showed me that Edge doesn't even try supporting dropping files and displays a "no go" icon. 

One more thing – I've been thinking about renaming `drop`'s `dropRange` to `dropPosition` because it seemed to me that it will always be a position, but it's not necessarily true. E.g. we may want to support dropping on object type elements (like image widgets) in a way that it will be replacing the image and not inserting the content before/after it. This will come up once we'll start working on the magicline stuff.