### PR TITLE
Content should not be inserted if there is nothing to insert

### DIFF
--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -165,6 +165,10 @@ export default class Clipboard extends Plugin {
 				// we use the $clipboardHolder item.
 				const modelFragment = dataController.toModel( data.content, '$clipboardHolder' );
 
+				if ( modelFragment.childCount == 0 ) {
+					return;
+				}
+
 				doc.enqueueChanges( () => {
 					dataController.insertContent( modelFragment, doc.selection );
 				} );

--- a/tests/clipboard.js
+++ b/tests/clipboard.js
@@ -179,7 +179,7 @@ describe( 'Clipboard feature', () => {
 			expect( stringifyModel( spy.args[ 0 ][ 0 ] ) ).to.equal( '<paragraph>x</paragraph>' );
 		} );
 
-		it( 'do not insert content when editor is read-only', () => {
+		it( 'does not insert content when editor is read-only', () => {
 			const dataTransferMock = createDataTransfer( { 'text/html': '<p>x</p>', 'text/plain': 'y' } );
 			const spy = sinon.stub( editor.data, 'insertContent' );
 
@@ -193,7 +193,7 @@ describe( 'Clipboard feature', () => {
 			sinon.assert.notCalled( spy );
 		} );
 
-		it( 'do not insert content if whole content was invalid', () => {
+		it( 'does not insert content if the whole content was invalid', () => {
 			// Whole content is invalid. Even though there is "view" content, the "model" content would be empty.
 			// Do not insert content in this case.
 			const dataTransferMock = createDataTransfer( { 'text/html': '<unknownTag></unknownTag>', 'text/plain': '' } );

--- a/tests/clipboard.js
+++ b/tests/clipboard.js
@@ -193,6 +193,20 @@ describe( 'Clipboard feature', () => {
 			sinon.assert.notCalled( spy );
 		} );
 
+		it( 'do not insert content if whole content was invalid', () => {
+			// Whole content is invalid. Even though there is "view" content, the "model" content would be empty.
+			// Do not insert content in this case.
+			const dataTransferMock = createDataTransfer( { 'text/html': '<unknownTag></unknownTag>', 'text/plain': '' } );
+			const spy = sinon.stub( editor.data, 'insertContent' );
+
+			editingView.fire( 'paste', {
+				dataTransfer: dataTransferMock,
+				preventDefault() {}
+			} );
+
+			sinon.assert.notCalled( spy );
+		} );
+
 		it( 'converts content in an "all allowed" context', () => {
 			// It's enough if we check this here with a text node and paragraph because if the conversion was made
 			// in a normal root, then text or paragraph wouldn't be allowed here.


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: `data.insertContent` should not be fired during pasting if all pasted content was incorrect and was converted to an empty `model.DocumentFragment`. Closes #37.