### PR TITLE
Internal: Disabled `clipboardInput` when editor is read-only.

### DIFF
--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -134,13 +134,15 @@ export default class Clipboard extends Plugin {
 
 		// The clipboard paste pipeline.
 
-		this.listenTo( viewDocument, 'clipboardInput', ( evt, data ) => {
-			// Pasting and dropping is disabled when editor is read-only.
-			// See: https://github.com/ckeditor/ckeditor5-clipboard/issues/26.
+		// Pasting and dropping is disabled when editor is read-only.
+		// See: https://github.com/ckeditor/ckeditor5-clipboard/issues/26.
+		this.listenTo( viewDocument, 'clipboardInput', evt => {
 			if ( editor.isReadOnly ) {
-				return;
+				evt.stop();
 			}
+		}, { priority: 'highest' } );
 
+		this.listenTo( viewDocument, 'clipboardInput', ( evt, data ) => {
 			const dataTransfer = data.dataTransfer;
 			let content = '';
 

--- a/tests/clipboard.js
+++ b/tests/clipboard.js
@@ -194,6 +194,29 @@ describe( 'Clipboard feature', () => {
 			sinon.assert.notCalled( spy );
 		} );
 
+		it( 'stops `clipboardInput` event on highest priority when editor is read-only', () => {
+			const dataTransferMock = createDataTransfer( { 'text/html': '<p>x</p>', 'text/plain': 'y' } );
+			const spy = sinon.spy();
+
+			viewDocument.on( 'clipboardInput', spy, { priority: 'high' } );
+
+			editor.isReadOnly = true;
+
+			viewDocument.fire( 'clipboardInput', {
+				dataTransfer: dataTransferMock
+			} );
+
+			sinon.assert.notCalled( spy );
+
+			editor.isReadOnly = false;
+
+			viewDocument.fire( 'clipboardInput', {
+				dataTransfer: dataTransferMock
+			} );
+
+			sinon.assert.calledOnce( spy );
+		} );
+
 		it( 'does not insert content if the whole content was invalid', () => {
 			// Whole content is invalid. Even though there is "view" content, the "model" content would be empty.
 			// Do not insert content in this case.


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Disabled `clipboardInput` when editor is read-only. Closes #48.
