### PR TITLE
Code sample in clipboard API docs updated

### DIFF
--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -49,10 +49,10 @@ import HtmlDataProcessor from '@ckeditor/ckeditor5-engine/src/dataprocessor/html
  *
  * At this stage the dataTransfer object can be processed by the features, which want to transform the original dataTransform.
  *
- *		this.listenTo( editor.editing.view, 'clipboardInput', ( evt, data ) => {
- *			const content = customTransform( data.dataTransfer.get( 'text/html' ) );
+ *		this.listenTo( editor.editing.view.document, 'clipboardInput', ( evt, data ) => {
+ *			const content = customTransform( data.dataTransfer.getData( 'text/html' ) );
  *			const transformedContent = transform( content );
- *			data.dataTransfer.set( 'text/html', transformedContent );
+ *			data.dataTransfer.setData( 'text/html', transformedContent );
  *		} );
  *
  * ## On {@link module:clipboard/clipboard~Clipboard#event:inputTransformation}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Code sample in clipboard API docs updated.

---

### Additional information

There is a small typo in clipboard code sample - instead of `data.dataTransfer.getData/setData` there is `data.dataTransfer.get/set`. As there are [only `getData/setData` methods](https://ckeditor.com/docs/ckeditor5/latest/api/module_clipboard_datatransfer-DataTransfer.html) I assume it wasn't updated after some code changes.
