### PR TITLE
The 'inputTransformation' event is now emitted with 'dataTransfer' object

### DIFF
--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -193,7 +193,7 @@ export default class Clipboard extends Plugin {
 
 			content = this._htmlDataProcessor.toView( content );
 
-			this.fire( 'inputTransformation', { content } );
+			this.fire( 'inputTransformation', { content, dataTransfer } );
 
 			view.scrollToTheSelection();
 		}, { priority: 'low' } );
@@ -253,8 +253,9 @@ export default class Clipboard extends Plugin {
 }
 
 /**
- * Fired with a `content`, which comes from the clipboard (was pasted or dropped) and
- * should be processed in order to be inserted into the editor.
+ * Fired with a `content` and `dataTransfer` objects. The `content` which comes from the clipboard (was pasted or dropped)
+ * should be processed in order to be inserted into the editor. The `dataTransfer` object is available
+ * in case the transformation functions needs access to a raw clipboard data.
  * It's part of the {@link module:clipboard/clipboard~Clipboard "clipboard pipeline"}.
  *
  * @see module:clipboard/clipboardobserver~ClipboardObserver
@@ -263,6 +264,7 @@ export default class Clipboard extends Plugin {
  * @param {Object} data Event data.
  * @param {module:engine/view/documentfragment~DocumentFragment} data.content Event data. Content to be inserted into the editor.
  * It can be modified by the event listeners. Read more about the clipboard pipelines in {@link module:clipboard/clipboard~Clipboard}
+ * @param {module:clipboard/datatransfer~DataTransfer} data.dataTransfer Data transfer instance.
  */
 
 /**

--- a/tests/clipboard.js
+++ b/tests/clipboard.js
@@ -73,6 +73,7 @@ describe( 'Clipboard feature', () => {
 
 				clipboardPlugin.on( 'inputTransformation', ( evt, data ) => {
 					expect( data.content ).is.instanceOf( ViewDocumentFragment );
+					expect( data.dataTransfer ).to.equal( dataTransferMock );
 					expect( stringifyView( data.content ) ).to.equal( '<p>x</p>' );
 
 					done();
@@ -109,6 +110,7 @@ describe( 'Clipboard feature', () => {
 
 				clipboardPlugin.on( 'inputTransformation', ( evt, data ) => {
 					expect( data.content ).is.instanceOf( ViewDocumentFragment );
+					expect( data.dataTransfer ).to.equal( dataTransferMock );
 					expect( stringifyView( data.content ) ).to.equal( '<p>x</p><p>y  z</p>' );
 
 					done();
@@ -136,6 +138,7 @@ describe( 'Clipboard feature', () => {
 
 			clipboardPlugin.on( 'inputTransformation', ( evt, data ) => {
 				expect( data.content ).is.instanceOf( ViewDocumentFragment );
+				expect( data.dataTransfer ).to.equal( dataTransferMock );
 				expect( stringifyView( data.content ) ).to.equal( '' );
 
 				expect( editorViewCalled.calledOnce ).to.be.true;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: The `inputTransformation` event is now emitted additionally with `dataTransfer` object. Closes #54 .

---

### Additional information

See #54.
