### PR TITLE
t/ckeditor5-upload/92: Fix: View event should not bubble up if the `clipboardInp...

### DIFF
--- a/src/clipboardobserver.js
+++ b/src/clipboardobserver.js
@@ -8,6 +8,7 @@
  */
 
 import DomEventObserver from '@ckeditor/ckeditor5-engine/src/view/observer/domeventobserver';
+import EventInfo from '@ckeditor/ckeditor5-utils/src/eventinfo';
 import DataTransfer from './datatransfer';
 
 /**
@@ -45,10 +46,19 @@ export default class ClipboardObserver extends DomEventObserver {
 
 			const targetRanges = data.dropRange ? [ data.dropRange ] : Array.from( viewDocument.selection.getRanges() );
 
-			viewDocument.fire( 'clipboardInput', {
+			const eventInfo = new EventInfo( viewDocument, 'clipboardInput' );
+
+			viewDocument.fire( eventInfo, {
 				dataTransfer: data.dataTransfer,
 				targetRanges
 			} );
+
+			// If CKEditor handled the input, do not bubble the original event any further.
+			// This helps external integrations recognize that fact and act accordingly.
+			// https://github.com/ckeditor/ckeditor5-upload/issues/92
+			if ( eventInfo.stop.called ) {
+				data.stopPropagation();
+			}
 		}
 	}
 

--- a/tests/clipboard.js
+++ b/tests/clipboard.js
@@ -191,6 +191,7 @@ describe( 'Clipboard feature', () => {
 
 			viewDocument.fire( 'paste', {
 				dataTransfer: dataTransferMock,
+				stopPropagation() {},
 				preventDefault() {}
 			} );
 
@@ -286,6 +287,7 @@ describe( 'Clipboard feature', () => {
 
 			viewDocument.fire( 'paste', {
 				dataTransfer: dataTransferMock,
+				stopPropagation() {},
 				preventDefault() {}
 			} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: View event should not bubble up if the `clipboardInput` was handled. Closes ckeditor/ckeditor5-upload#92.

---

### Additional information

Requires https://github.com/ckeditor/ckeditor5-image/pull/285.
