### PR TITLE
Handled paste and drop events no longer propagate up DOM tree.

### DIFF
--- a/tests/pasting-integration.js
+++ b/tests/pasting-integration.js
@@ -196,6 +196,7 @@ describe( 'Pasting – integration', () => {
 function pasteHtml( editor, html ) {
 	editor.editing.view.document.fire( 'paste', {
 		dataTransfer: createDataTransfer( { 'text/html': html } ),
+		stopPropagation() {},
 		preventDefault() {}
 	} );
 }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Handled paste and drop events no longer propagate up DOM tree. Closes ckeditor/ckeditor5#6464.
